### PR TITLE
Update mime.py

### DIFF
--- a/zmail/mime.py
+++ b/zmail/mime.py
@@ -83,7 +83,7 @@ class Mail:
                     name, raw = attachment
                     part = MIMEBase('application', 'octet-stream')
                     part.set_payload(raw)
-                    part['Content-Disposition'] = 'attachment;filename="{}"'.format(name)
+                    part['Content-Disposition'] = 'attachment;filename="{}"'.format(Header(name).encode())
                     encode_base64(part)
                     mime.attach(part)
                 else:


### PR DESCRIPTION
解决附件以tuple的形式传入时，中文文件名不能正常显示的问题